### PR TITLE
Delist scam XRUNE

### DIFF
--- a/src/constants/terraswap.json
+++ b/src/constants/terraswap.json
@@ -83,6 +83,10 @@
     {
       "contract_addr": "terra14f7u8z4eqpxcrp4xr6knhgfp5n4h68nwy3yzg5",
       "comment": "delisted DKWON"
+    },
+    {
+      "contract_addr": "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl",
+      "comment": "delisted scam XRUNE"
     }
   ]
 }


### PR DESCRIPTION
Somebody deployed a scam token with the same symbol as the Thorstarter one and people buying it are not able to sell it back loosing their funds.

Let me know if this is the right way to blacklist a token.

(Side note: I've been looking to add a logo for the XRUNE token to help the situation but it seems like logos are not in this repo anymore and looking at the code, it's not clear where they come from)