### PR TITLE
fix: stop drawing a screen while getting gas from undefined fee

### DIFF
--- a/src/forms/SwapForm.tsx
+++ b/src/forms/SwapForm.tsx
@@ -827,8 +827,8 @@ const SwapForm = ({ type, tabs }: { type: Type; tabs: TabViewProps }) => {
   ])
   useEffect(() => {
     setValue(Key.gasPrice, gasPrice || "")
-    setValue(Key.feeValue, gasPrice ? ceil(times(fee.gas, gasPrice)) : "")
-  }, [fee.gas, gasPrice, setValue])
+    setValue(Key.feeValue, gasPrice ? ceil(times(fee?.gas, gasPrice)) : "")
+  }, [fee?.gas, gasPrice, setValue])
 
   useEffect(() => {
     setValue(Key.feeValue, ceil(times(fee?.gas, gasPrice)) || "")


### PR DESCRIPTION
[how to reproduce]
1. connect to `mainnet` on Terra station extension
2. execute `Connect Wallet` on Terraswap classic
3. the screen displays empty (expected: show unsupported network modal)

cause: unable to retrieve fee from network